### PR TITLE
Fix buildpack so it works for client too

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,9 +20,13 @@ mv $BUILD_DIR /tmp/git-export
 
 cd /tmp/git-export
 echo "removing \`.git' only..."
-cp gitmodules .gitmodules
 find . -name .git | xargs rm -rf
+echo 'removing .profile.d'
 rm -fr .profile.d
+if [ -f gitmodules ] ; then
+  echo 'replacing .gitmodules with  gitmodules'
+  cp gitmodules .gitmodules
+fi
 
 mkdir -p $BUILD_DIR
 mv /tmp/git-export $BUILD_DIR/

--- a/bin/nix-install-proot
+++ b/bin/nix-install-proot
@@ -60,7 +60,7 @@ EOF
 
 (
   compilehook=$(find $BUILD_DIR/nix/store -name heroku-compile-hook -type f)
-  if [ -x $compilehook ] ; then
+  if [ -x "$compilehook" ] ; then
       topic "Running compile hook at $compilehook"
       source $compilehook
   fi
@@ -68,10 +68,10 @@ EOF
 
 topic "Creating run_in_proot.sh"
 (
-    outapi=$(echo "$OUT" | grep circuithub-api)
+    appout=$(echo "$OUT" | grep $NIX_TARGET)
     cat <<EOF > $BUILD_DIR/bin/run_in_proot.sh
 #!/bin/bash
-export PATH=$outapi/bin:\$PATH
+export PATH=$appout/bin:\$PATH
 CMD=\$1
 \$CMD "\${@:2}"
 EOF


### PR DESCRIPTION
* fix check for $compilehook, check it succeeded
  when env was empty when it should have failed.
* make output path matching explicit via NIX_TARGET
  instead of hardcoding it to circuithbu-api
* only copy gitmodules over .gitmodules if it is actually
  present